### PR TITLE
Added AllProducts export to client/index.js

### DIFF
--- a/client/components/index.js
+++ b/client/components/index.js
@@ -5,4 +5,5 @@
  */
 export {default as Navbar} from './navbar'
 export {default as UserHome} from './user-home'
+export {default as AllProducts} from './AllProducts'
 export {Login, Signup} from './auth-form'


### PR DESCRIPTION
I had forgotten to add the AllProducts to the list of exports in client/index.js
Now the /products route renders every item in the products table.
