### PR TITLE
Pagination #26

### DIFF
--- a/client/components/CategoryPanel.js
+++ b/client/components/CategoryPanel.js
@@ -1,15 +1,10 @@
 import React from 'react'
 import {connect} from 'react-redux'
-import {
-  toggleCategorySelected,
-  setCategoriesTrue,
-  setCategoriesFalse
-} from '../store/index'
+import {toggleCategorySelected, setCategoriesTrue, setCategoriesFalse} from '../store/index'
 
 //this needs to be a func comp
 
 const CategoryPanel = props => {
-  const {categoriesAreSelected, categories} = props
   const handleCheck = event => {
     const id = event.target.name
     props.toggleCategorySelected(id)
@@ -17,14 +12,10 @@ const CategoryPanel = props => {
   const handleClick = () => {
     props.setCategoriesTrue()
   }
-  const handleClickFalse = () => {
+  const handleClickFalse =() =>{
     props.setCategoriesFalse()
   }
-  const handleSubmit = event => {
-    event.preventDefault()
-    let filteredCat = categoriesAreSelected.keys.filter(id => categoriesAreSelected[id])
-    console.log(`catId=${filteredCat}`)
-  }
+  const {categoriesAreSelected, categories} = props
   return (
     <nav className="panel column is-2 is-fullheight is-narrow">
       <p className="panel-heading">Product Filter</p>
@@ -32,12 +23,12 @@ const CategoryPanel = props => {
         <a className="is-active">Categories</a>
       </p>
       <div className="panel-block">
-        {/* <p className="control has-icons-left">
+        <p className="control has-icons-left">
           <input className="input is-small" type="text" placeholder="search" />
           <span className="icon is-small is-left">
             <i className="fas fa-search" aria-hidden="true" />
           </span>
-        </p> */}
+        </p>
       </div>
       {categories.map(category => {
         return (
@@ -68,15 +59,6 @@ const CategoryPanel = props => {
           onClick={handleClick}
         >
           Reset Filter
-        </button>
-      </div>
-      <div className="panel-block">
-        <button
-          className="button is-link is-outlined is-fullwidth"
-          type="button"
-          onClick={handleSubmit}
-        >
-          Filter Results
         </button>
       </div>
     </nav>

--- a/client/components/CategoryPanel.js
+++ b/client/components/CategoryPanel.js
@@ -1,10 +1,18 @@
 import React from 'react'
 import {connect} from 'react-redux'
-import {toggleCategorySelected, setCategoriesTrue, setCategoriesFalse} from '../store/index'
-
-//this needs to be a func comp
+import {
+  toggleCategorySelected,
+  setCategoriesTrue,
+  setCategoriesFalse
+} from '../store/index'
+import {Link} from 'react-router-dom'
 
 const CategoryPanel = props => {
+  // util function to create a new query string
+
+  const {categoriesAreSelected, categories, location} = props
+  const params = location.search.slice(1).split('&')
+
   const handleCheck = event => {
     const id = event.target.name
     props.toggleCategorySelected(id)
@@ -12,10 +20,22 @@ const CategoryPanel = props => {
   const handleClick = () => {
     props.setCategoriesTrue()
   }
-  const handleClickFalse =() =>{
+  const handleClickFalse = () => {
     props.setCategoriesFalse()
   }
-  const {categoriesAreSelected, categories} = props
+
+  const filteredCat = Object.keys(categoriesAreSelected).filter(
+    id => categoriesAreSelected[id]
+  )
+
+  const linkBuilder = (currentParams, catIds) => {
+    const returnParams = currentParams
+      .filter(param => !param.startsWith('catIds='))
+      .concat(`catIds=${JSON.stringify(catIds)}`)
+    return `?${returnParams.join('&')}`
+  }
+  const submitUrl = linkBuilder(params, filteredCat)
+
   return (
     <nav className="panel column is-2 is-fullheight is-narrow">
       <p className="panel-heading">Product Filter</p>
@@ -23,12 +43,12 @@ const CategoryPanel = props => {
         <a className="is-active">Categories</a>
       </p>
       <div className="panel-block">
-        <p className="control has-icons-left">
+        {/* <p className="control has-icons-left">
           <input className="input is-small" type="text" placeholder="search" />
           <span className="icon is-small is-left">
             <i className="fas fa-search" aria-hidden="true" />
           </span>
-        </p>
+        </p> */}
       </div>
       {categories.map(category => {
         return (
@@ -60,6 +80,16 @@ const CategoryPanel = props => {
         >
           Reset Filter
         </button>
+      </div>
+      <div className="panel-block">
+        <Link to={submitUrl}>
+          <button
+            className="button is-link is-outlined is-fullwidth"
+            type="button"
+          >
+            Filter Results
+          </button>
+        </Link>
       </div>
     </nav>
   )

--- a/client/components/CategoryPanel.js
+++ b/client/components/CategoryPanel.js
@@ -10,7 +10,7 @@ import {Link} from 'react-router-dom'
 const CategoryPanel = props => {
   // util function to create a new query string
 
-  const {categoriesAreSelected, categories, location} = props
+  const {categoriesAreSelected, categories, location, searchKey} = props
   const params = location.search.slice(1).split('&')
 
   const handleCheck = event => {
@@ -35,21 +35,31 @@ const CategoryPanel = props => {
     return `?${returnParams.join('&')}`
   }
   const submitUrl = linkBuilder(params, filteredCat)
+  const keyRemover = (currentParams) => {
+    const returnParams = currentParams
+      .filter(param => !param.startsWith('key='))
+    return `?${returnParams.join('&')}`
+  }
+  const keyRemoveUrl = keyRemover(params)
 
   return (
     <nav className="panel column is-2 is-fullheight is-narrow">
       <p className="panel-heading">Product Filter</p>
+      {searchKey && (
+        <p className="panel-block">
+          <p className="control has-icons-right">
+            Search Term: {searchKey}
+            <Link to={keyRemoveUrl}>
+              <span className="panel-icon is-right">
+                <i className="delete" />
+              </span>
+            </Link>
+          </p>
+        </p>
+      )}
       <p className="panel-tabs">
-        <a className="is-active">Categories</a>
+        <p className="is-active is-size-5">Categories</p>
       </p>
-      <div className="panel-block">
-        {/* <p className="control has-icons-left">
-          <input className="input is-small" type="text" placeholder="search" />
-          <span className="icon is-small is-left">
-            <i className="fas fa-search" aria-hidden="true" />
-          </span>
-        </p> */}
-      </div>
       {categories.map(category => {
         return (
           <label className="panel-block" key={category.id}>
@@ -65,7 +75,7 @@ const CategoryPanel = props => {
       })}
       <div className="panel-block">
         <button
-          className="button is-link is-outlined is-fullwidth"
+          className="button is-outlined is-fullwidth"
           type="button"
           onClick={handleClickFalse}
         >
@@ -74,22 +84,20 @@ const CategoryPanel = props => {
       </div>
       <div className="panel-block">
         <button
-          className="button is-link is-outlined is-fullwidth"
+          className="button is-outlined is-fullwidth"
           type="button"
           onClick={handleClick}
         >
-          Reset Filter
+          Check All
         </button>
       </div>
       <div className="panel-block">
-        <Link to={submitUrl}>
-          <button
-            className="button is-link is-outlined is-fullwidth"
-            type="button"
-          >
-            Filter Results
-          </button>
-        </Link>
+        <button
+          className="button is-link is-outlined is-fullwidth"
+          type="button"
+        >
+          <Link to={submitUrl}>Apply Filter </Link>
+        </button>
       </div>
     </nav>
   )

--- a/client/components/CategoryPanel.js
+++ b/client/components/CategoryPanel.js
@@ -13,6 +13,27 @@ const CategoryPanel = props => {
   const {categoriesAreSelected, categories, location, searchKey} = props
   const params = location.search.slice(1).split('&')
 
+  // generate URLs
+  const filteredCat = Object.keys(categoriesAreSelected).filter(
+    id => categoriesAreSelected[id]
+  )
+  const linkBuilder = (currentParams, catIds) => {
+    let returnParams = currentParams.filter(param => !param.startsWith('catIds='))
+    if (catIds.length < categories.length) returnParams = returnParams.concat(`catIds=${JSON.stringify(catIds)}`)
+    return `?${returnParams.join('&')}`
+  }
+  const submitUrl = linkBuilder(params, filteredCat)
+  const keyRemover = currentParams => {
+    const returnParams = currentParams.filter(
+      param => !param.startsWith('key=')
+    )
+    return `?${returnParams.join('&')}`
+  }
+  const keyRemoveUrl = keyRemover(params)
+
+  // disable apply filter btn if catIds empty
+  const applyBtnDisabled = filteredCat.length === 0;
+  // handle events
   const handleCheck = event => {
     const id = event.target.name
     props.toggleCategorySelected(id)
@@ -23,24 +44,9 @@ const CategoryPanel = props => {
   const handleClickFalse = () => {
     props.setCategoriesFalse()
   }
-
-  const filteredCat = Object.keys(categoriesAreSelected).filter(
-    id => categoriesAreSelected[id]
-  )
-
-  const linkBuilder = (currentParams, catIds) => {
-    const returnParams = currentParams
-      .filter(param => !param.startsWith('catIds='))
-      .concat(`catIds=${JSON.stringify(catIds)}`)
-    return `?${returnParams.join('&')}`
+  const handleApply = () => {
+    props.history.push(submitUrl)
   }
-  const submitUrl = linkBuilder(params, filteredCat)
-  const keyRemover = (currentParams) => {
-    const returnParams = currentParams
-      .filter(param => !param.startsWith('key='))
-    return `?${returnParams.join('&')}`
-  }
-  const keyRemoveUrl = keyRemover(params)
 
   return (
     <nav className="panel column is-2 is-fullheight is-narrow">
@@ -95,8 +101,10 @@ const CategoryPanel = props => {
         <button
           className="button is-link is-outlined is-fullwidth"
           type="button"
+          onClick={handleApply}
+          disabled={applyBtnDisabled}
         >
-          <Link to={submitUrl}>Apply Filter </Link>
+          Apply Filter
         </button>
       </div>
     </nav>

--- a/client/components/CategoryPanel.js
+++ b/client/components/CategoryPanel.js
@@ -1,10 +1,15 @@
 import React from 'react'
 import {connect} from 'react-redux'
-import {toggleCategorySelected, setCategoriesTrue, setCategoriesFalse} from '../store/index'
+import {
+  toggleCategorySelected,
+  setCategoriesTrue,
+  setCategoriesFalse
+} from '../store/index'
 
 //this needs to be a func comp
 
 const CategoryPanel = props => {
+  const {categoriesAreSelected, categories} = props
   const handleCheck = event => {
     const id = event.target.name
     props.toggleCategorySelected(id)
@@ -12,10 +17,14 @@ const CategoryPanel = props => {
   const handleClick = () => {
     props.setCategoriesTrue()
   }
-  const handleClickFalse =() =>{
+  const handleClickFalse = () => {
     props.setCategoriesFalse()
   }
-  const {categoriesAreSelected, categories} = props
+  const handleSubmit = event => {
+    event.preventDefault()
+    let filteredCat = categoriesAreSelected.keys.filter(id => categoriesAreSelected[id])
+    console.log(`catId=${filteredCat}`)
+  }
   return (
     <nav className="panel column is-2 is-fullheight is-narrow">
       <p className="panel-heading">Product Filter</p>
@@ -23,12 +32,12 @@ const CategoryPanel = props => {
         <a className="is-active">Categories</a>
       </p>
       <div className="panel-block">
-        <p className="control has-icons-left">
+        {/* <p className="control has-icons-left">
           <input className="input is-small" type="text" placeholder="search" />
           <span className="icon is-small is-left">
             <i className="fas fa-search" aria-hidden="true" />
           </span>
-        </p>
+        </p> */}
       </div>
       {categories.map(category => {
         return (
@@ -59,6 +68,15 @@ const CategoryPanel = props => {
           onClick={handleClick}
         >
           Reset Filter
+        </button>
+      </div>
+      <div className="panel-block">
+        <button
+          className="button is-link is-outlined is-fullwidth"
+          type="button"
+          onClick={handleSubmit}
+        >
+          Filter Results
         </button>
       </div>
     </nav>

--- a/client/components/PageSelector.js
+++ b/client/components/PageSelector.js
@@ -3,10 +3,11 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 const PageSelector = props => {
-  const {page, limit, pageCount, key} = props.paginatedProducts
+  const {page, limit, pageCount, key, catIds} = props.paginatedProducts
   if (pageCount < 1) return null
   let paramUrl = '/products?'
   if (key) paramUrl += `key=${key}&`;
+  if (catIds) paramUrl +=`catIds=${JSON.stringify(catIds)}&`
   paramUrl += `limit=${limit}&page=`;
   const prevPageUrl = `${paramUrl}${page-1}`;
   const nextPageUrl = `${paramUrl}${page+1}`;

--- a/client/components/PageSelector.js
+++ b/client/components/PageSelector.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+const PageSelector = props => {
+  const {page, limit, pageCount, key} = props.paginatedProducts
+  if (pageCount < 1) return null
+  let paramUrl = '/products?'
+  if (key) paramUrl += `key=${key}&`;
+  paramUrl += `limit=${limit}&page=`;
+  const prevPageUrl = `${paramUrl}${page-1}`;
+  const nextPageUrl = `${paramUrl}${page+1}`;
+  return (
+    <nav className="pagination" role="navigation" aria-label="pagination">
+      {page > 1 && (<Link to={prevPageUrl} className="pagination-previous">
+        Previous
+      </Link>)}
+      {page < pageCount && (<Link to={nextPageUrl} className="pagination-next">
+        Next
+      </Link>)}
+      <ul className="pagination-list">
+        {new Array(pageCount).fill('').map((_, idx) => {
+          const pageNum = idx + 1
+          const isCurrent = (page === pageNum) ? 'is-current' : null;
+          const ariaLabel = (isCurrent) ? `Page ${pageNum}` : `Goto page ${pageNum}`;
+          const paramUrlWithNum = `${paramUrl}${pageNum}`
+          return (
+            <li key={pageNum}>
+              <Link to={paramUrlWithNum} className={`pagination-link ${isCurrent}`} aria-label={ariaLabel}>
+                {pageNum}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}
+
+const mapStateToProps = ({paginatedProducts}) => ({
+  paginatedProducts
+})
+
+export default connect(mapStateToProps)(PageSelector);

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -1,30 +1,47 @@
 import React from 'react'
 import ProductCard from './ProductCard'
-import { connect } from 'react-redux'
+import {connect} from 'react-redux'
 import CategoryPanel from './CategoryPanel'
-import { fetchProducts } from '../store/index';
-import { destroySearch } from '../store/searchProducts'
+// import { fetchProducts } from '../store/index';
+import {fetchPaginatedProducts} from '../store/index'
+import { Link } from 'react-router-dom'
+// import { destroySearch } from '../store/searchProducts'
+
+
 //keep as class instead of function component, since we will be adding more function later
 class ProductView extends React.Component {
-  componentDidMount() {
-    this.props.fetchProducts();
+  state = {loading: true}
+  async componentDidMount() {
+    // const queryObj = {}
+    const urlParamStr = this.props.location.search.slice(1) // get params from URL
+    // const urlParamArr = urlParamStr.split('&') // split into array
+    // urlParamArr.forEach(param => {
+    //   // loop over each parameter
+    //   const idxEqlSign = param.indexOf('=')
+    //   // end this loop if eqls sign not found, or at ends
+    //   if (idxEqlSign < 1 || idxEqlSign === param.length - 1) return undefined
+    //   const paramName = param.slice(0, idxEqlSign)
+    //   const paramVal = param.slice(idxEqlSign + 1)
+    //   queryObj[paramName] = paramVal // push params into queryObj
+    // })
+    await this.props.fetchPaginatedProducts(urlParamStr)
+    this.setState({loading: false})
   }
 
-  filterProduct = () => {
+  componentDidUpdate = async (prevProps) => {
+    if (this.props.location !== prevProps.location) {
+      const urlParamStr = this.props.location.search.slice(1)
+      this.setState({loading: true})
+      await this.props.fetchPaginatedProducts(urlParamStr)
+      this.setState({loading: false})
+    }
+  }
+
+  filterProduct = products => {
     let filter = []
-    let obj = Object.keys(this.props.searchProduct)
-    if (obj.length) {
-      this.props.searchProduct.forEach(product => {
-        for (let i = 0; i < product.Category.length; i++) {
-          let cat = product.Category[i]
-          if (this.props.categoriesAreSelected[cat.id]) {
-            filter.push(product)
-            return
-          }
-        }
-      })
-    } else {
-      this.props.products.forEach(product => {
+    let productCount = Object.keys(products)
+    if (productCount.length) {
+      products.forEach(product => {
         for (let i = 0; i < product.Category.length; i++) {
           let cat = product.Category[i]
           if (this.props.categoriesAreSelected[cat.id]) {
@@ -38,7 +55,17 @@ class ProductView extends React.Component {
   }
 
   render() {
-    const filterProduct = this.filterProduct()
+    const paginatedProducts = this.props.paginatedProducts
+    const filterProduct = this.filterProduct(paginatedProducts.products)
+    const loading = this.state.loading;
+    if (loading) return (
+      <div className="main-content columns is-fullheight">
+          <CategoryPanel />
+          <div className="container column">
+            <div className="is-3">Loading...</div>
+          </div>
+        </div>
+    )
     if (filterProduct.length === 0) {
       return (
         <div className="main-content columns is-fullheight">
@@ -53,24 +80,77 @@ class ProductView extends React.Component {
         <div className="main-content columns is-fullheight">
           <CategoryPanel />
           <div className="container column">
-            <div className="tile is-ancestor" style={{ "flexwrap": 'row' }}>
-              {filterProduct.map(product => (
-                <ProductCard key={product.id} product={product} />
-              ))}
+            <div className="container">
+              {this.renderPageSelect()}
+              <div
+                className="section tile is-ancestor"
+                style={{flexwrap: 'row'}}
+              >
+                {filterProduct.map(product => (
+                  <ProductCard key={product.id} product={product} />
+                ))}
+              </div>
             </div>
           </div>
         </div>
       )
     }
   }
+  renderPageSelect() {
+    const {page, limit, pageCount, key} = this.props.paginatedProducts
+    if (pageCount < 1) return null
+    let paramUrl = '/products?'
+    if (key) paramUrl += `key=${key}&`;
+    paramUrl += `limit=${limit}&page=`;
+    const prevPageUrl = `${paramUrl}${page-1}`;
+    const nextPageUrl = `${paramUrl}${page+1}`;
+    return (
+      <nav className="pagination" role="navigation" aria-label="pagination">
+        {page > 1 && (<Link to={prevPageUrl} className="pagination-previous">
+          Previous
+        </Link>)}
+        {page < pageCount && (<Link to={nextPageUrl} className="pagination-next">
+          Next
+        </Link>)}
+        <ul className="pagination-list">
+          {new Array(pageCount).fill('').map((_, idx) => {
+            const pageNum = idx + 1
+            const isCurrent = (page === pageNum) ? 'is-current' : null;
+            const ariaLabel = (isCurrent) ? `Page ${pageNum}` : `Goto page ${pageNum}`;
+            const paramUrlWithNum = `${paramUrl}${pageNum}`
+            return (
+              <li key={pageNum}>
+                <Link to={paramUrlWithNum} className={`pagination-link ${isCurrent}`} aria-label={ariaLabel}>
+                  {pageNum}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+    )
+  }
 }
-const mapStateToProps = ({ products, categories, categoriesAreSelected, searchProduct }) => {
-  return { products, categories, categoriesAreSelected, searchProduct }
-}
-const mapDispatchToProps = (dispatch) => {
+const mapStateToProps = ({
+  products,
+  categories,
+  categoriesAreSelected,
+  searchProduct,
+  paginatedProducts
+}) => {
   return {
-    fetchProducts: () => dispatch(fetchProducts()),
-    destroySearch: () => dispatch(destroySearch())
+    products,
+    categories,
+    categoriesAreSelected,
+    searchProduct,
+    paginatedProducts
+  }
+}
+const mapDispatchToProps = dispatch => {
+  return {
+    fetchPaginatedProducts: queryObj =>
+      dispatch(fetchPaginatedProducts(queryObj))
+    // destroySearch: () => dispatch(destroySearch())
   }
 }
 export default connect(mapStateToProps, mapDispatchToProps)(ProductView)

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -58,7 +58,7 @@ class ProductView extends React.Component {
     if (filterProduct.length === 0) {
       return (
         <div className="main-content columns is-fullheight">
-          <CategoryPanel />
+          <CategoryPanel key = "no-products"/>
           <div className="container column">
             <div>No Products</div>
           </div>
@@ -72,7 +72,7 @@ class ProductView extends React.Component {
     const foundResultsMessage = `Found ${count} products. Displaying results ${startProdNum} to ${endProdNum}`
     return (
       <div className="main-content columns is-fullheight">
-        <CategoryPanel />
+        <CategoryPanel key="products-loaded"/>
         <div className="container column">
           <div className="container">
             <PageSelector />

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -2,17 +2,21 @@ import React from 'react'
 import ProductCard from './ProductCard'
 import {connect} from 'react-redux'
 import CategoryPanel from './CategoryPanel'
-import {fetchPaginatedProducts} from '../store/index'
+import {fetchPaginatedProducts, selectCategoriesWithArray} from '../store/index'
 import PageSelector from './PageSelector'
-
 //keep as class instead of function component, since we will be adding more function later
 class ProductView extends React.Component {
   state = {loading: true}
 
   async componentDidMount() {
     const urlParamStr = this.props.location.search.slice(1)
-    await this.props.fetchPaginatedProducts(urlParamStr)
+    await this.props.fetchPaginatedProducts(urlParamStr) // fetch results using URL
+    let catIds = this.props.paginatedProducts.catIds;
+    if (catIds) {
+      this.props.selectCategoriesWithArray(catIds)
+    }
     this.setState({loading: false})
+
   }
 
   componentDidUpdate = async prevProps => {
@@ -37,24 +41,24 @@ class ProductView extends React.Component {
       )
     }
     const paginatedProducts = this.props.paginatedProducts
+    const {page, pageCount, limit, key, products, count, catIds} = paginatedProducts
     if (paginatedProducts.products.length === 0) {
       return (
         <div className="main-content columns is-fullheight">
-          <CategoryPanel location={this.props.location}/>
+          <CategoryPanel searchKey={key} location={this.props.location} history={this.props.history} />
           <div className="container column">
             <div>No Products</div>
           </div>
         </div>
       )
     }
-    const {page, pageCount, limit, key, products, count, catIds} = paginatedProducts
     const offset = (page - 1) * limit;
     const startProdNum = offset + 1
     const endProdNum = offset + products.length;
     const foundResultsMessage = `Found ${count} products. Displaying results ${startProdNum} to ${endProdNum}`
     return (
       <div className="main-content columns is-fullheight">
-        <CategoryPanel location={this.props.location} searchKey={key}/>
+        <CategoryPanel location={this.props.location} searchKey={key} history = {this.props.history}/>
         <div className="container column">
           <div className="container">
             <PageSelector />
@@ -81,7 +85,8 @@ const mapStateToProps = ({categoriesAreSelected, paginatedProducts}) => {
 const mapDispatchToProps = dispatch => {
   return {
     fetchPaginatedProducts: queryObj =>
-      dispatch(fetchPaginatedProducts(queryObj))
+      dispatch(fetchPaginatedProducts(queryObj)),
+    selectCategoriesWithArray: catIds => dispatch(selectCategoriesWithArray(catIds))
   }
 }
 export default connect(mapStateToProps, mapDispatchToProps)(ProductView)

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -24,29 +24,29 @@ class ProductView extends React.Component {
     }
   }
 
-  filterProduct = products => {
-    let filter = []
-    let productCount = Object.keys(products)
-    if (productCount.length) {
-      products.forEach(product => {
-        for (let i = 0; i < product.Category.length; i++) {
-          let cat = product.Category[i]
-          if (this.props.categoriesAreSelected[cat.id]) {
-            filter.push(product)
-            return
-          }
-        }
-      })
-    }
-    return filter
-  }
+  // filterProduct = products => {
+  //   let filter = []
+  //   let productCount = Object.keys(products)
+  //   if (productCount.length) {
+  //     products.forEach(product => {
+  //       for (let i = 0; i < product.Category.length; i++) {
+  //         let cat = product.Category[i]
+  //         if (this.props.categoriesAreSelected[cat.id]) {
+  //           filter.push(product)
+  //           return
+  //         }
+  //       }
+  //     })
+  //   }
+  //   return filter
+  // }
 
   render() {
     const loading = this.state.loading
     if (loading) {
       return (
         <div className="main-content columns is-fullheight">
-          <CategoryPanel />
+          <CategoryPanel {...this.props}/>
           <div className="container column">
             <div className="is-3">Loading...</div>
           </div>
@@ -54,11 +54,11 @@ class ProductView extends React.Component {
       )
     }
     const paginatedProducts = this.props.paginatedProducts
-    const filterProduct = this.filterProduct(paginatedProducts.products)
-    if (filterProduct.length === 0) {
+    // const filterProduct = this.filterProduct(paginatedProducts.products)
+    if (paginatedProducts.products.length === 0) {
       return (
         <div className="main-content columns is-fullheight">
-          <CategoryPanel />
+          <CategoryPanel location={this.props.location}/>
           <div className="container column">
             <div>No Products</div>
           </div>
@@ -72,7 +72,7 @@ class ProductView extends React.Component {
     const foundResultsMessage = `Found ${count} products. Displaying results ${startProdNum} to ${endProdNum}`
     return (
       <div className="main-content columns is-fullheight">
-        <CategoryPanel />
+        <CategoryPanel location={this.props.location}/>
         <div className="container column">
           <div className="container">
             <PageSelector />
@@ -80,7 +80,7 @@ class ProductView extends React.Component {
               <p className="is-size-5 has-text-left">{foundResultsMessage}</p>
             </div>
             <div id='listOfPokemons' className="section tile is-ancestor" >
-              {filterProduct.map(product => (
+              {products.map(product => (
                 <ProductCard key={product.id} product={product} />
               ))}
             </div>

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -11,19 +11,9 @@ import { Link } from 'react-router-dom'
 //keep as class instead of function component, since we will be adding more function later
 class ProductView extends React.Component {
   state = {loading: true}
+
   async componentDidMount() {
-    // const queryObj = {}
-    const urlParamStr = this.props.location.search.slice(1) // get params from URL
-    // const urlParamArr = urlParamStr.split('&') // split into array
-    // urlParamArr.forEach(param => {
-    //   // loop over each parameter
-    //   const idxEqlSign = param.indexOf('=')
-    //   // end this loop if eqls sign not found, or at ends
-    //   if (idxEqlSign < 1 || idxEqlSign === param.length - 1) return undefined
-    //   const paramName = param.slice(0, idxEqlSign)
-    //   const paramVal = param.slice(idxEqlSign + 1)
-    //   queryObj[paramName] = paramVal // push params into queryObj
-    // })
+    const urlParamStr = this.props.location.search.slice(1)
     await this.props.fetchPaginatedProducts(urlParamStr)
     this.setState({loading: false})
   }
@@ -132,17 +122,17 @@ class ProductView extends React.Component {
   }
 }
 const mapStateToProps = ({
-  products,
-  categories,
+  // products,
+  // categories,
   categoriesAreSelected,
-  searchProduct,
+  // searchProduct,
   paginatedProducts
 }) => {
   return {
-    products,
-    categories,
+    // products,
+    // categories,
     categoriesAreSelected,
-    searchProduct,
+    // searchProduct,
     paginatedProducts
   }
 }
@@ -150,7 +140,6 @@ const mapDispatchToProps = dispatch => {
   return {
     fetchPaginatedProducts: queryObj =>
       dispatch(fetchPaginatedProducts(queryObj))
-    // destroySearch: () => dispatch(destroySearch())
   }
 }
 export default connect(mapStateToProps, mapDispatchToProps)(ProductView)

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -58,7 +58,7 @@ class ProductView extends React.Component {
     if (filterProduct.length === 0) {
       return (
         <div className="main-content columns is-fullheight">
-          <CategoryPanel key = "no-products"/>
+          <CategoryPanel />
           <div className="container column">
             <div>No Products</div>
           </div>
@@ -72,7 +72,7 @@ class ProductView extends React.Component {
     const foundResultsMessage = `Found ${count} products. Displaying results ${startProdNum} to ${endProdNum}`
     return (
       <div className="main-content columns is-fullheight">
-        <CategoryPanel key="products-loaded"/>
+        <CategoryPanel />
         <div className="container column">
           <div className="container">
             <PageSelector />

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -2,11 +2,8 @@ import React from 'react'
 import ProductCard from './ProductCard'
 import {connect} from 'react-redux'
 import CategoryPanel from './CategoryPanel'
-// import { fetchProducts } from '../store/index';
 import {fetchPaginatedProducts} from '../store/index'
-import { Link } from 'react-router-dom'
-// import { destroySearch } from '../store/searchProducts'
-
+import PageSelector from './PageSelector'
 
 //keep as class instead of function component, since we will be adding more function later
 class ProductView extends React.Component {
@@ -18,7 +15,7 @@ class ProductView extends React.Component {
     this.setState({loading: false})
   }
 
-  componentDidUpdate = async (prevProps) => {
+  componentDidUpdate = async prevProps => {
     if (this.props.location !== prevProps.location) {
       const urlParamStr = this.props.location.search.slice(1)
       this.setState({loading: true})
@@ -45,17 +42,19 @@ class ProductView extends React.Component {
   }
 
   render() {
-    const paginatedProducts = this.props.paginatedProducts
-    const filterProduct = this.filterProduct(paginatedProducts.products)
-    const loading = this.state.loading;
-    if (loading) return (
-      <div className="main-content columns is-fullheight">
+    const loading = this.state.loading
+    if (loading) {
+      return (
+        <div className="main-content columns is-fullheight">
           <CategoryPanel />
           <div className="container column">
             <div className="is-3">Loading...</div>
           </div>
         </div>
-    )
+      )
+    }
+    const paginatedProducts = this.props.paginatedProducts
+    const filterProduct = this.filterProduct(paginatedProducts.products)
     if (filterProduct.length === 0) {
       return (
         <div className="main-content columns is-fullheight">
@@ -65,74 +64,38 @@ class ProductView extends React.Component {
           </div>
         </div>
       )
-    } else {
-      return (
-        <div className="main-content columns is-fullheight">
-          <CategoryPanel />
-          <div className="container column">
+    }
+    const {page, pageCount, limit, key, products, count} = paginatedProducts
+    const offset = (page - 1) * limit;
+    const startProdNum = offset + 1
+    const endProdNum = offset + products.length;
+    const foundResultsMessage = `Found ${count} products. Displaying results ${startProdNum} to ${endProdNum}`
+    return (
+      <div className="main-content columns is-fullheight">
+        <CategoryPanel />
+        <div className="container column">
+          <div className="container">
+            <PageSelector />
             <div className="container">
-              {this.renderPageSelect()}
-              <div
-                className="section tile is-ancestor"
-                style={{flexwrap: 'row'}}
-              >
-                {filterProduct.map(product => (
-                  <ProductCard key={product.id} product={product} />
-                ))}
-              </div>
+              <p className="is-size-5 has-text-left">{foundResultsMessage}</p>
+            </div>
+            <div
+              className="section tile is-ancestor"
+              style={{flexwrap: 'row'}}
+            >
+              {filterProduct.map(product => (
+                <ProductCard key={product.id} product={product} />
+              ))}
             </div>
           </div>
         </div>
-      )
-    }
-  }
-  renderPageSelect() {
-    const {page, limit, pageCount, key} = this.props.paginatedProducts
-    if (pageCount < 1) return null
-    let paramUrl = '/products?'
-    if (key) paramUrl += `key=${key}&`;
-    paramUrl += `limit=${limit}&page=`;
-    const prevPageUrl = `${paramUrl}${page-1}`;
-    const nextPageUrl = `${paramUrl}${page+1}`;
-    return (
-      <nav className="pagination" role="navigation" aria-label="pagination">
-        {page > 1 && (<Link to={prevPageUrl} className="pagination-previous">
-          Previous
-        </Link>)}
-        {page < pageCount && (<Link to={nextPageUrl} className="pagination-next">
-          Next
-        </Link>)}
-        <ul className="pagination-list">
-          {new Array(pageCount).fill('').map((_, idx) => {
-            const pageNum = idx + 1
-            const isCurrent = (page === pageNum) ? 'is-current' : null;
-            const ariaLabel = (isCurrent) ? `Page ${pageNum}` : `Goto page ${pageNum}`;
-            const paramUrlWithNum = `${paramUrl}${pageNum}`
-            return (
-              <li key={pageNum}>
-                <Link to={paramUrlWithNum} className={`pagination-link ${isCurrent}`} aria-label={ariaLabel}>
-                  {pageNum}
-                </Link>
-              </li>
-            )
-          })}
-        </ul>
-      </nav>
+      </div>
     )
   }
 }
-const mapStateToProps = ({
-  // products,
-  // categories,
-  categoriesAreSelected,
-  // searchProduct,
-  paginatedProducts
-}) => {
+const mapStateToProps = ({categoriesAreSelected, paginatedProducts}) => {
   return {
-    // products,
-    // categories,
     categoriesAreSelected,
-    // searchProduct,
     paginatedProducts
   }
 }

--- a/client/components/ProductView.js
+++ b/client/components/ProductView.js
@@ -24,23 +24,6 @@ class ProductView extends React.Component {
     }
   }
 
-  // filterProduct = products => {
-  //   let filter = []
-  //   let productCount = Object.keys(products)
-  //   if (productCount.length) {
-  //     products.forEach(product => {
-  //       for (let i = 0; i < product.Category.length; i++) {
-  //         let cat = product.Category[i]
-  //         if (this.props.categoriesAreSelected[cat.id]) {
-  //           filter.push(product)
-  //           return
-  //         }
-  //       }
-  //     })
-  //   }
-  //   return filter
-  // }
-
   render() {
     const loading = this.state.loading
     if (loading) {
@@ -54,7 +37,6 @@ class ProductView extends React.Component {
       )
     }
     const paginatedProducts = this.props.paginatedProducts
-    // const filterProduct = this.filterProduct(paginatedProducts.products)
     if (paginatedProducts.products.length === 0) {
       return (
         <div className="main-content columns is-fullheight">
@@ -65,14 +47,14 @@ class ProductView extends React.Component {
         </div>
       )
     }
-    const {page, pageCount, limit, key, products, count} = paginatedProducts
+    const {page, pageCount, limit, key, products, count, catIds} = paginatedProducts
     const offset = (page - 1) * limit;
     const startProdNum = offset + 1
     const endProdNum = offset + products.length;
     const foundResultsMessage = `Found ${count} products. Displaying results ${startProdNum} to ${endProdNum}`
     return (
       <div className="main-content columns is-fullheight">
-        <CategoryPanel location={this.props.location}/>
+        <CategoryPanel location={this.props.location} searchKey={key}/>
         <div className="container column">
           <div className="container">
             <PageSelector />

--- a/client/components/SearchBar.js
+++ b/client/components/SearchBar.js
@@ -17,7 +17,7 @@ export class SearchBar extends Component {
     this.setState({
       value: ''
     })
-    history.push(`/products/search?key=${this.state.value}`)
+    history.push(`/products?key=${this.state.value}`)
   }
   render() {
     return (

--- a/client/components/SearchBar.js
+++ b/client/components/SearchBar.js
@@ -13,11 +13,13 @@ export class SearchBar extends Component {
     this.setState({ value: event.target.value })
   }
   handleClick = () => {
-    // this.props.searchedProduct(this.state.value);
+    const destroy = this.props.destroy;
     this.setState({
       value: ''
     })
-    history.push(`/products?key=${this.state.value}`)
+    if (!this.state.value) history.push(`/products`);
+    else history.push(`/products?key=${this.state.value}`)
+    destroy();
   }
   render() {
     return (

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -15,4 +15,4 @@ export { default as UnmatchedRoute } from './UnmatchedRoute'
 export { default as SignupSuccess } from './SignupSuccess'
 export { default as SignupConfirm } from './SignupConfirm'
 export { default as SearchProductView } from './SearchProductView'
-
+export { default as PageSelector } from './PageSelector'

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -57,7 +57,7 @@ const Navbar = ({ handleClick, isLoggedIn, destroy }) => (
             <div className="navbar-item">Contact</div>
           </div>
         </div>
-        <div className="navbar-item is-center"><SearchBar /></div>
+        <div className="navbar-item is-center"><SearchBar destroy = {destroy} /></div>
       </div>
     </div>
 

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { NavLink, Link } from 'react-router-dom'
 import { logout } from '../store'
 import SearchBar from './SearchBar'
-import { destroySearch } from '../store/searchProducts'
+import { destroySearch, setCategoriesTrue } from '../store/'
 const Navbar = ({ handleClick, isLoggedIn, destroy }) => (
   <nav
     className="navbar is-dark is-fixed-top"
@@ -106,8 +106,9 @@ const mapDispatch = dispatch => {
     handleClick() {
       dispatch(logout())
     },
-    destroy() {
-      dispatch(destroySearch())
+    destroy: async () => {
+      await dispatch(destroySearch())
+      await dispatch(setCategoriesTrue())
     }
   }
 }

--- a/client/index.js
+++ b/client/index.js
@@ -6,7 +6,6 @@ import history from './history'
 import store from './store'
 import App from './app'
 import 'bulma/css/bulma.css';
-
 // establishes socket connection
 import './socket'
 

--- a/client/routes.js
+++ b/client/routes.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import { withRouter, Route, Switch } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Login, Signup, UserHome, ProductView, CurrentProduct, AddProduct, EditProduct, UnmatchedRoute, SearchProductView, SignupSuccess, SignupConfirm } from './components'
-import { me, fetchProducts, fetchCategories } from './store'
+import { me, fetchProducts, fetchCategories, fetchPaginatedProducts} from './store'
 
 /**
  * COMPONENT

--- a/client/store/categoriesAreSelected.js
+++ b/client/store/categoriesAreSelected.js
@@ -1,23 +1,21 @@
 import axios from 'axios'
 
-
-
 /* -----------------    ACTION TYPES    ------------------ */
-
 const SET_CATEGORIES = 'SET_CATEGORIES'
 const TOGGLE_CATEGORY_SELECTED = 'TOGGLE_CATEGORY_SELECTED'
 const SET_CATEGORIES_TRUE = 'SET_CATEGORIES_TRUE'
 const SET_CATEGORIES_FALSE = 'SET_CATEGORIES_FALSE'
+const SELECT_CATEGORIES_WITH_ARRAY = 'SELECT_CATEGORIES_WITH_ARRAY'
 
 /* ------------     ACTION CREATORS      ------------------ */
 
-// const setCategories = categories => ({ type: SET_CATEGORIES, categories })
 export const toggleCategorySelected = id => ({
   type: TOGGLE_CATEGORY_SELECTED,
   id
 })
- export const setCategoriesTrue = ()=> ({ type: SET_CATEGORIES_TRUE })
- export const setCategoriesFalse = ()=> ({ type: SET_CATEGORIES_FALSE })
+export const setCategoriesTrue = () => ({type: SET_CATEGORIES_TRUE})
+export const setCategoriesFalse = () => ({type: SET_CATEGORIES_FALSE})
+export const selectCategoriesWithArray = (catIds) => ({type: SELECT_CATEGORIES_WITH_ARRAY, catIds })
 
 /* ------------          REDUCER         ------------------ */
 
@@ -25,8 +23,12 @@ const initialState = {}
 let allTrueObj = {}
 let allFalseObj = {}
 
-export default function categoriesAreSelectedReducer(state = initialState, action) {
+export default function categoriesAreSelectedReducer(
+  state = initialState,
+  action
+) {
   try {
+    let newState;
     switch (action.type) {
       case SET_CATEGORIES:
         action.categories.forEach(category => {
@@ -37,19 +39,23 @@ export default function categoriesAreSelectedReducer(state = initialState, actio
         })
         return allTrueObj
       case TOGGLE_CATEGORY_SELECTED:
-        return { ...state, [action.id]: !state[action.id] }
+        return {...state, [action.id]: !state[action.id]}
       case SET_CATEGORIES_TRUE:
         return {...allTrueObj}
-
       case SET_CATEGORIES_FALSE:
         return {...allFalseObj}
+      case SELECT_CATEGORIES_WITH_ARRAY:
+        newState = {...allFalseObj};
+        action.catIds.forEach(catId => {
+          newState[catId] = true
+        })
+        return newState;
       default:
-        return state;
+        return state
     }
   } catch (err) {
-    console.error(err);
+    console.error(err)
   }
 }
 
 /* ------------       THUNK CREATORS     ------------------ */
-

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -9,8 +9,8 @@ import categories from './categories'
 import categoriesAreSelected from './categoriesAreSelected'
 import signupToken from './signupToken'
 import searchProduct from './searchProducts'
-
-const reducer = combineReducers({ user, products, currentProduct, categories, categoriesAreSelected, signupToken, searchProduct })
+import paginatedProducts from './paginatedProducts'
+const reducer = combineReducers({ user, products, currentProduct, categories, categoriesAreSelected, signupToken, searchProduct , paginatedProducts})
 
 const middleware = composeWithDevTools(
   applyMiddleware(thunkMiddleware, createLogger({ collapsed: true }))
@@ -25,3 +25,4 @@ export * from './categories'
 export * from './categoriesAreSelected'
 export * from './signupToken'
 export * from './searchProducts'
+export * from './paginatedProducts'

--- a/client/store/paginatedProducts.js
+++ b/client/store/paginatedProducts.js
@@ -1,0 +1,49 @@
+import axios from 'axios'
+
+const initialState = {
+  products: [],
+}
+/* -----------------    ACTION TYPES    ------------------ */
+
+const SET_PAGINATED_PRODUCTS_STATE = 'SET_PAGINATED_PRODUCTS_STATE';
+
+
+/* ------------     ACTION CREATORS      ------------------ */
+
+export const setPaginatedProductsState = newState => ({type: SET_PAGINATED_PRODUCTS_STATE, newState})
+
+/* ------------          REDUCER         ------------------ */
+
+export default function paginatedProductsReducer(state = initialState, action) {
+  try {
+    switch (action.type) {
+      case SET_PAGINATED_PRODUCTS_STATE:
+        return {...action.newState}
+      default:
+        return state
+    }
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+/* ------------       THUNK CREATORS     ------------------ */
+export const fetchPaginatedProducts = (queryStr) => async dispatch => {
+  try {
+    const response = await axios.get(`/api/products?${queryStr}`)
+    const action = setPaginatedProductsState(response.data)
+    dispatch(action)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+// export const createNewProduct = (productData) => async dispatch => {
+//   try {
+//     const response = await axios.post('/api/products', productData);
+//     const action = addNewProduct(response.data)
+//     dispatch(action)
+//   } catch (err) {
+//     console.error(err)
+//   }
+// }

--- a/client/store/paginatedProducts.js
+++ b/client/store/paginatedProducts.js
@@ -30,7 +30,11 @@ export default function paginatedProductsReducer(state = initialState, action) {
 /* ------------       THUNK CREATORS     ------------------ */
 export const fetchPaginatedProducts = (queryStr) => async dispatch => {
   try {
-    const response = await axios.get(`/api/products?${queryStr}`)
+    const response = await axios.get(`/api/products?${queryStr}`, {
+      validateStatus: function (status) {
+        return status < 400; // Reject only if the status code is greater than or equal to 500
+      }
+    })
     const action = setPaginatedProductsState(response.data)
     dispatch(action)
   } catch (err) {

--- a/client/store/paginatedProducts.js
+++ b/client/store/paginatedProducts.js
@@ -30,11 +30,7 @@ export default function paginatedProductsReducer(state = initialState, action) {
 /* ------------       THUNK CREATORS     ------------------ */
 export const fetchPaginatedProducts = (queryStr) => async dispatch => {
   try {
-    const response = await axios.get(`/api/products?${queryStr}`, {
-      validateStatus: function (status) {
-        return status < 400; // Reject only if the status code is greater than or equal to 500
-      }
-    })
+    const response = await axios.get(`/api/products?${queryStr}`)
     const action = setPaginatedProductsState(response.data)
     dispatch(action)
   } catch (err) {

--- a/script/seed.js
+++ b/script/seed.js
@@ -8,8 +8,8 @@ async function seed() {
   console.log('db synced!')
 
   const users = await Promise.all([
-    User.create({ email: 'cody@email.com', password: '123', isAdmin: true }),
-    User.create({ email: 'murphy@email.com', password: '123' })
+    User.create({ email: 'cody@email.com', password: '123', isAdmin: true, isEmailVerified: true }),
+    User.create({ email: 'murphy@email.com', password: '123', isEmailVerified: true })
   ])
   const catTypes = ['Normal', 'Fire', 'Water', 'Electric', 'Grass', 'Ice', 'Fighting', 'Poison', 'Ground',
     'Flying', 'Psychic', 'Bug', 'Rock', 'Ghost', 'Dragon'];
@@ -42,7 +42,7 @@ async function seed() {
   ]);
 
   await Promise.all(products.map(product => {
-    return product.addCategory(categories[Math.ceil(Math.random() * 18)])
+    return product.addCategory(categories[Math.floor(Math.random() * catTypes.length)])
   }))
 
   console.log(`seeded ${users.length} users`)

--- a/server/api/products.js
+++ b/server/api/products.js
@@ -35,16 +35,16 @@ router.get('/', async (req, res, next) => {
   let searchedItem = req.query.key
   try {
     if (!req.query.catIds) {
-      // which page # to return - default 1
       options.offset = offset
       options.limit = limit
-      if (searchedItem)
+      if (searchedItem) {
         searchedItem =
           searchedItem.slice(0, 1).toUpperCase() +
           searchedItem.slice(1).toLowerCase()
-      options.where = {
-        title: {
-          [Op.like]: `%${searchedItem}%`
+        options.where = {
+          title: {
+            [Op.like]: `%${searchedItem}%`
+          }
         }
       }
       products = await Product.findAndCountAll(options)
@@ -60,10 +60,20 @@ router.get('/', async (req, res, next) => {
     } else if (req.query.catIds) {
       // filter products the hard way w/o sequelize
       let categoryCount = await Category.count()
-      let catIds, response, count
-      let filteredProducts = []
-      catIds = JSON.parse(req.query.catIds).map(catId => +catId)
+      if (searchedItem) {
+        searchedItem =
+          searchedItem.slice(0, 1).toUpperCase() +
+          searchedItem.slice(1).toLowerCase()
+        options.where = {
+          title: {
+            [Op.like]: `%${searchedItem}%`
+          }
+        }
+      }
       products = await Product.findAll(options)
+      let catIds, response, count
+      catIds = JSON.parse(req.query.catIds).map(catId => +catId)
+      let filteredProducts = []
       products.forEach(product => {
         for (let i = 0; i < product.Category.length; i++) {
           let cat = product.Category[i]

--- a/server/api/products.js
+++ b/server/api/products.js
@@ -20,7 +20,6 @@ router.get('/', async (req, res, next) => {
     } else if (limit < 1 ) {
       limit = 1;
     }
-    const numberOfProducts = Product.count();
     let offset = (page - 1) * limit;
     const options = {
       offset,
@@ -47,8 +46,16 @@ router.get('/', async (req, res, next) => {
       }
     }
 
-    const products = await Product.findAll(options)
-    res.json(products)
+    const products = await Product.findAndCountAll(options)
+    const response = {
+      count: products.count,
+      pageCount: Math.ceil(products.count/limit),
+      key: req.query.key,
+      page,
+      limit,
+      products: products.rows
+    };
+    res.json(response);
   } catch (err) {
     next(err)
   }

--- a/server/api/products.js
+++ b/server/api/products.js
@@ -83,10 +83,16 @@ router.get('/', async (req, res, next) => {
           }
         }
       })
+      let paginatedFiltered = []
+      for (let prodIdx = offset; prodIdx < filteredProducts.length; prodIdx++) {
+        let product = filteredProducts[prodIdx];
+        paginatedFiltered.push(product);
+        if (paginatedFiltered.length === limit) break
+      }
       count = filteredProducts.length
       response = {
         count,
-        products: filteredProducts.slice(offset),
+        products: paginatedFiltered,
         pageCount: Math.ceil(count / limit),
         key: req.query.key,
         catIds,

--- a/server/api/products.js
+++ b/server/api/products.js
@@ -7,12 +7,12 @@ const Op = Sequelize.Op
 router.get('/', async (req, res, next) => {
   try {
     // which page # to return - default 1
-    let page = parseInt(req.query.page, 20);
+    let page = parseInt(req.query.page, 10);
     if (isNaN(page) || page < 1) {
       page = 1;
     }
     // items per request - default 20, max 50
-    let limit = parseInt(req.query.limit, 20);
+    let limit = parseInt(req.query.limit, 10);
     if (isNaN(limit)) {
       limit = 20;
     } else if (limit > 50) {


### PR DESCRIPTION
This feature is not fully ready to be merged. The main features work:
- sends a query to backend based on URL (if no values found, uses default 20 per page, sorted by ascending product ID)
- paginates results
- results stored as paginatedProducts (with pagination data)
- default number of results per fetch is 20
- integrates search bar feature (SearchProductView is now redundant).

Some features that can still be added:
- selecting per page parameter. Currently there is no way to change the per page parameter except by manually typing it into the URL
- choosing how to sort results (Date, Alphabetical, Price, Quantity, etc. Maybe even rating)

Outstanding issues:
- Filtering results by category needs to be refactored to send a new request to the server, not filter the currently loaded products. (page will display 'No results found' if no results on the current page match category filters, even if there's a result on the next page)
- Any features that rely on the previous API for /products might need to be refactored.